### PR TITLE
Fix FVSAND_GPU_KERNEL_LAUNCH macro

### DIFF
--- a/src/LocalMesh.C
+++ b/src/LocalMesh.C
@@ -174,7 +174,7 @@ void LocalMesh::CreateGridMetrics()
   // compute cell center_ds
 
   const int N = ncells + nhalo;
-  FVSAND_GPU_KERNEL_LAUNCH( cell_center, N, center_d, x_d, nvcft_d, 
+  FVSAND_GPU_KERNEL_LAUNCH( cell_center, (N*3), center_d, x_d, nvcft_d, 
                             cell2node_d, N );
 
   // compute cell normals and volume_d

--- a/src/fvsand_gpu.h
+++ b/src/fvsand_gpu.h
@@ -29,7 +29,7 @@ namespace gpu {
 
 #define FVSAND_GPU_KERNEL_LAUNCH(func, N, ... )                               \
 {                                                                             \
-  constexpr int FVSAND_BLOCK_SIZE = 1024;                                     \
+  constexpr int FVSAND_BLOCK_SIZE = 256;                                      \
   const int __n_blocks = ( N + FVSAND_BLOCK_SIZE-1 ) / FVSAND_BLOCK_SIZE ;    \
   FVSAND_GPU_LAUNCH_FUNC( func                                                \
                         , __n_blocks                                          \

--- a/src/fvsand_gpu.h
+++ b/src/fvsand_gpu.h
@@ -30,14 +30,12 @@ namespace gpu {
 #define FVSAND_GPU_KERNEL_LAUNCH(func, N, ... )                               \
 {                                                                             \
   constexpr int FVSAND_BLOCK_SIZE = 1024;                                     \
-  constexpr int SHARED_MEM  = 0;                                              \
-  constexpr int CUDA_STREAM = 0;                                              \
-  const int n_blocks = ( N + FVSAND_BLOCK_SIZE-1 ) / FVSAND_BLOCK_SIZE ;      \
+  const int __n_blocks = ( N + FVSAND_BLOCK_SIZE-1 ) / FVSAND_BLOCK_SIZE ;    \
   FVSAND_GPU_LAUNCH_FUNC( func                                                \
-                        , n_blocks                                            \
+                        , __n_blocks                                          \
                         , FVSAND_BLOCK_SIZE                                   \
-                        , SHARED_MEM                                          \
-                        , CUDA_STREAM                                         \
+                        , 0  /* SHARED_MEM */                                 \
+                        , 0  /* CUDA_STREAM */                                \
                         , __VA_ARGS__ );                                      \
 }
 


### PR DESCRIPTION
Summary
========

This PR fixes the compilation issues with `FVSAND_GPU_KERNEL_LAUNCH` macro, introduced in 65d704d967db21a1d200569da255eebb08070521. Moreover, changes the `LocalMesh::CreateGridMetrics` routine to use the `FVSAND_GPU_KERNEL_LAUNCH` macro instead.